### PR TITLE
pybind11_add_module does not take include directories as input.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ INCLUDE_DIRECTORIES(
 
 pybind11_add_module(${PROJECT_NAME}
     src/keypoints.cpp
-    ${MY_HEADERS}
 )
 target_link_libraries(${PROJECT_NAME}
     ${PCL_LIBRARIES}


### PR DESCRIPTION
Pybind's addmodule does not take include directories as inputs. It consumes source .cpp files.

On my system this was generating the following error
```
-- Configuring done
CMake Error at pybind11/tools/pybind11Tools.cmake:131 (add_library):
  Cannot find source file:

    /<redacted>/Development/include/eigen3

  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
  .hxx .in .txx
Call Stack (most recent call first):
  CMakeLists.txt:32 (pybind11_add_module)
```